### PR TITLE
AXIOM-502: make AXIOM usable in GraalVM Native Image

### DIFF
--- a/aspects/core-aspects/src/main/java/org/apache/axiom/core/CoreParentNodeSupport.aj
+++ b/aspects/core-aspects/src/main/java/org/apache/axiom/core/CoreParentNodeSupport.aj
@@ -297,12 +297,7 @@ public aspect CoreParentNodeSupport {
     }
     
     public final <T> NodeIterator<T> CoreParentNode.coreGetNodes(Axis axis, Class<T> type, Semantics semantics) {
-        return new AbstractNodeIterator<T>(this, axis, type, semantics) {
-            @Override
-            protected boolean matches(CoreNode node) throws CoreModelException {
-                return true;
-            }
-        };
+        return new NodesIterator<T>(this, axis, type, semantics);
     }
     
     public final <T extends CoreElement> NodeIterator<T> CoreParentNode.coreGetElements(Axis axis, Class<T> type, ElementMatcher<? super T> matcher, String namespaceURI, String name, Semantics semantics) {

--- a/aspects/core-aspects/src/main/java/org/apache/axiom/core/NodesIterator.java
+++ b/aspects/core-aspects/src/main/java/org/apache/axiom/core/NodesIterator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axiom.core;
+
+final class NodesIterator<T> extends AbstractNodeIterator<T> {
+
+    public NodesIterator(CoreParentNode startNode, Axis axis, Class<T> type, Semantics semantics) {
+        super(startNode, axis, type, semantics);
+    }
+
+    @Override
+    protected boolean matches(CoreNode node) throws CoreModelException {
+        return true;
+    }
+
+}


### PR DESCRIPTION
When building an application using the GraalVM Native Image compiler it
fails when AXIOM is used in the application. The GraalVM compiler fails
with the exception java.lang.InternalError: Enclosing method not found.

This seems to be caused by missing type information for the anonymous
AbstractNodeIterator implementation in CoreParentNodeSupport.

By replacing the anonymous inner class with a concrete implementation
AXIOM can be used with the GraalVM Native Image compiler.