### PR TITLE
Extract interface from SOAPHelper

### DIFF
--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/SOAPHelperImpl.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/SOAPHelperImpl.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axiom.soap.impl.common;
+
+import javax.xml.namespace.QName;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.axiom.om.impl.common.OMNamespaceImpl;
+import org.apache.axiom.om.impl.intf.factory.AxiomElementType;
+import org.apache.axiom.soap.SOAPConstants;
+import org.apache.axiom.soap.SOAPVersion;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPBody;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPEnvelope;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPFault;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPFaultCode;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPFaultDetail;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPFaultReason;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPFaultRole;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPHeader;
+import org.apache.axiom.soap.impl.intf.AxiomSOAPHeaderBlock;
+import org.apache.axiom.soap.impl.intf.SOAPHelper;
+
+public abstract class SOAPHelperImpl implements SOAPHelper {
+    private final SOAPVersion version;
+    private final OMNamespace namespace;
+    private final String specName;
+    private final AxiomElementType<? extends AxiomSOAPEnvelope> envelopeType;
+    private final AxiomElementType<? extends AxiomSOAPHeader> headerType;
+    private final QName headerQName;
+    private final AxiomElementType<? extends AxiomSOAPHeaderBlock> headerBlockType;
+    private final AxiomElementType<? extends AxiomSOAPBody> bodyType;
+    private final QName bodyQName;
+    private final AxiomElementType<? extends AxiomSOAPFault> faultType;
+    private final QName faultQName;
+    private final AxiomElementType<? extends AxiomSOAPFaultCode> faultCodeType;
+    private final AxiomElementType<? extends AxiomSOAPFaultReason> faultReasonType;
+    private final AxiomElementType<? extends AxiomSOAPFaultRole> faultRoleType;
+    private final AxiomElementType<? extends AxiomSOAPFaultDetail> faultDetailType;
+    private final QName mustUnderstandAttributeQName;
+    private final QName roleAttributeQName;
+    private final QName relayAttributeQName;
+
+    protected SOAPHelperImpl(
+            SOAPVersion version,
+            String specName,
+            AxiomElementType<? extends AxiomSOAPEnvelope> envelopeType,
+            AxiomElementType<? extends AxiomSOAPHeader> headerType,
+            AxiomElementType<? extends AxiomSOAPHeaderBlock> headerBlockType,
+            AxiomElementType<? extends AxiomSOAPBody> bodyType,
+            AxiomElementType<? extends AxiomSOAPFault> faultType,
+            AxiomElementType<? extends AxiomSOAPFaultCode> faultCodeType,
+            AxiomElementType<? extends AxiomSOAPFaultReason> faultReasonType,
+            AxiomElementType<? extends AxiomSOAPFaultRole> faultRoleType,
+            AxiomElementType<? extends AxiomSOAPFaultDetail> faultDetailType,
+            String roleAttributeLocalName,
+            String relayAttributeLocalName) {
+        this.version = version;
+        namespace = new OMNamespaceImpl(version.getEnvelopeURI(), SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        this.specName = specName;
+        this.envelopeType = envelopeType;
+        this.headerType = headerType;
+        headerQName = new QName(
+                version.getEnvelopeURI(), SOAPConstants.HEADER_LOCAL_NAME, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        this.headerBlockType = headerBlockType;
+        this.bodyType = bodyType;
+        bodyQName = new QName(
+                version.getEnvelopeURI(), SOAPConstants.BODY_LOCAL_NAME, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        this.faultType = faultType;
+        faultQName = new QName(
+                version.getEnvelopeURI(),
+                SOAPConstants.SOAPFAULT_LOCAL_NAME,
+                SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        this.faultCodeType = faultCodeType;
+        this.faultReasonType = faultReasonType;
+        this.faultRoleType = faultRoleType;
+        this.faultDetailType = faultDetailType;
+        mustUnderstandAttributeQName = new QName(
+                version.getEnvelopeURI(),
+                SOAPConstants.ATTR_MUSTUNDERSTAND,
+                SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        roleAttributeQName = new QName(
+                version.getEnvelopeURI(), roleAttributeLocalName, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+        relayAttributeQName = relayAttributeLocalName == null
+                ? null
+                : new QName(
+                        version.getEnvelopeURI(), relayAttributeLocalName, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
+    }
+
+    @Override
+    public final SOAPVersion getVersion() {
+        return version;
+    }
+
+    @Override
+    public final String getEnvelopeURI() {
+        return version.getEnvelopeURI();
+    }
+
+    @Override
+    public final OMNamespace getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public final String getSpecName() {
+        return specName;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPEnvelope> getEnvelopeType() {
+        return envelopeType;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPHeader> getHeaderType() {
+        return headerType;
+    }
+
+    @Override
+    public final QName getHeaderQName() {
+        return headerQName;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPHeaderBlock> getHeaderBlockType() {
+        return headerBlockType;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPBody> getBodyType() {
+        return bodyType;
+    }
+
+    @Override
+    public final QName getBodyQName() {
+        return bodyQName;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPFault> getFaultType() {
+        return faultType;
+    }
+
+    @Override
+    public final QName getFaultQName() {
+        return faultQName;
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPFaultCode> getFaultCodeType() {
+        return faultCodeType;
+    }
+
+    @Override
+    public final QName getFaultCodeQName() {
+        return version.getFaultCodeQName();
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPFaultReason> getFaultReasonType() {
+        return faultReasonType;
+    }
+
+    @Override
+    public final QName getFaultReasonQName() {
+        return version.getFaultReasonQName();
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPFaultRole> getFaultRoleType() {
+        return faultRoleType;
+    }
+
+    @Override
+    public final QName getFaultRoleQName() {
+        return version.getFaultRoleQName();
+    }
+
+    @Override
+    public final AxiomElementType<? extends AxiomSOAPFaultDetail> getFaultDetailType() {
+        return faultDetailType;
+    }
+
+    @Override
+    public final QName getFaultDetailQName() {
+        return version.getFaultDetailQName();
+    }
+
+    @Override
+    public final QName getMustUnderstandAttributeQName() {
+        return mustUnderstandAttributeQName;
+    }
+
+    @Override
+    public final QName getRoleAttributeQName() {
+        return roleAttributeQName;
+    }
+
+    @Override
+    public final QName getRelayAttributeQName() {
+        return relayAttributeQName;
+    }
+}

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/builder/SOAPModel.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/builder/SOAPModel.java
@@ -29,9 +29,9 @@ import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAPConstants;
 import org.apache.axiom.soap.SOAPProcessingException;
+import org.apache.axiom.soap.impl.common.soap11.SOAP11Helper;
+import org.apache.axiom.soap.impl.common.soap12.SOAP12Helper;
 import org.apache.axiom.soap.impl.intf.SOAPHelper;
-import org.apache.axiom.soap.impl.intf.soap11.SOAP11Helper;
-import org.apache.axiom.soap.impl.intf.soap12.SOAP12Helper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/soap11/SOAP11Helper.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/soap11/SOAP11Helper.java
@@ -16,45 +16,45 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.axiom.soap.impl.intf.soap12;
+package org.apache.axiom.soap.impl.common.soap11;
 
 import org.apache.axiom.om.OMMetaFactory;
 import org.apache.axiom.om.impl.intf.factory.AxiomNodeFactory;
-import org.apache.axiom.soap.SOAP12Constants;
+import org.apache.axiom.soap.SOAP11Constants;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.SOAPVersion;
-import org.apache.axiom.soap.impl.intf.SOAPHelper;
+import org.apache.axiom.soap.impl.common.SOAPHelperImpl;
 
-public final class SOAP12Helper extends SOAPHelper {
-    public static final SOAP12Helper INSTANCE = new SOAP12Helper();
+public final class SOAP11Helper extends SOAPHelperImpl {
+    public static final SOAP11Helper INSTANCE = new SOAP11Helper();
 
-    private SOAP12Helper() {
+    private SOAP11Helper() {
         super(
-                SOAPVersion.SOAP12,
-                "SOAP 1.2",
-                AxiomNodeFactory::createSOAP12Envelope,
-                AxiomNodeFactory::createSOAP12Header,
-                AxiomNodeFactory::createSOAP12HeaderBlock,
-                AxiomNodeFactory::createSOAP12Body,
-                AxiomNodeFactory::createSOAP12Fault,
-                AxiomNodeFactory::createSOAP12FaultCode,
-                AxiomNodeFactory::createSOAP12FaultReason,
-                AxiomNodeFactory::createSOAP12FaultRole,
-                AxiomNodeFactory::createSOAP12FaultDetail,
-                SOAP12Constants.SOAP_ROLE,
-                SOAP12Constants.SOAP_RELAY);
+                SOAPVersion.SOAP11,
+                "SOAP 1.1",
+                AxiomNodeFactory::createSOAP11Envelope,
+                AxiomNodeFactory::createSOAP11Header,
+                AxiomNodeFactory::createSOAP11HeaderBlock,
+                AxiomNodeFactory::createSOAP11Body,
+                AxiomNodeFactory::createSOAP11Fault,
+                AxiomNodeFactory::createSOAP11FaultCode,
+                AxiomNodeFactory::createSOAP11FaultReason,
+                AxiomNodeFactory::createSOAP11FaultRole,
+                AxiomNodeFactory::createSOAP11FaultDetail,
+                SOAP11Constants.ATTR_ACTOR,
+                null);
     }
 
     @Override
     public SOAPFactory getSOAPFactory(OMMetaFactory metaFactory) {
-        return metaFactory.getSOAP12Factory();
+        return metaFactory.getSOAP11Factory();
     }
 
     @Override
     public Boolean parseBoolean(String literal) {
-        if (literal.equals("true") || literal.equals("1")) {
+        if (literal.equals("1")) {
             return Boolean.TRUE;
-        } else if (literal.equals("false") || literal.equals("0")) {
+        } else if (literal.equals("0")) {
             return Boolean.FALSE;
         } else {
             return null;
@@ -63,6 +63,6 @@ public final class SOAP12Helper extends SOAPHelper {
 
     @Override
     public String formatBoolean(boolean value) {
-        return String.valueOf(value);
+        return value ? "1" : "0";
     }
 }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/soap12/SOAP12Helper.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/common/soap12/SOAP12Helper.java
@@ -16,45 +16,45 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.axiom.soap.impl.intf.soap11;
+package org.apache.axiom.soap.impl.common.soap12;
 
 import org.apache.axiom.om.OMMetaFactory;
 import org.apache.axiom.om.impl.intf.factory.AxiomNodeFactory;
-import org.apache.axiom.soap.SOAP11Constants;
+import org.apache.axiom.soap.SOAP12Constants;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.SOAPVersion;
-import org.apache.axiom.soap.impl.intf.SOAPHelper;
+import org.apache.axiom.soap.impl.common.SOAPHelperImpl;
 
-public final class SOAP11Helper extends SOAPHelper {
-    public static final SOAP11Helper INSTANCE = new SOAP11Helper();
+public final class SOAP12Helper extends SOAPHelperImpl {
+    public static final SOAP12Helper INSTANCE = new SOAP12Helper();
 
-    private SOAP11Helper() {
+    private SOAP12Helper() {
         super(
-                SOAPVersion.SOAP11,
-                "SOAP 1.1",
-                AxiomNodeFactory::createSOAP11Envelope,
-                AxiomNodeFactory::createSOAP11Header,
-                AxiomNodeFactory::createSOAP11HeaderBlock,
-                AxiomNodeFactory::createSOAP11Body,
-                AxiomNodeFactory::createSOAP11Fault,
-                AxiomNodeFactory::createSOAP11FaultCode,
-                AxiomNodeFactory::createSOAP11FaultReason,
-                AxiomNodeFactory::createSOAP11FaultRole,
-                AxiomNodeFactory::createSOAP11FaultDetail,
-                SOAP11Constants.ATTR_ACTOR,
-                null);
+                SOAPVersion.SOAP12,
+                "SOAP 1.2",
+                AxiomNodeFactory::createSOAP12Envelope,
+                AxiomNodeFactory::createSOAP12Header,
+                AxiomNodeFactory::createSOAP12HeaderBlock,
+                AxiomNodeFactory::createSOAP12Body,
+                AxiomNodeFactory::createSOAP12Fault,
+                AxiomNodeFactory::createSOAP12FaultCode,
+                AxiomNodeFactory::createSOAP12FaultReason,
+                AxiomNodeFactory::createSOAP12FaultRole,
+                AxiomNodeFactory::createSOAP12FaultDetail,
+                SOAP12Constants.SOAP_ROLE,
+                SOAP12Constants.SOAP_RELAY);
     }
 
     @Override
     public SOAPFactory getSOAPFactory(OMMetaFactory metaFactory) {
-        return metaFactory.getSOAP11Factory();
+        return metaFactory.getSOAP12Factory();
     }
 
     @Override
     public Boolean parseBoolean(String literal) {
-        if (literal.equals("1")) {
+        if (literal.equals("true") || literal.equals("1")) {
             return Boolean.TRUE;
-        } else if (literal.equals("0")) {
+        } else if (literal.equals("false") || literal.equals("0")) {
             return Boolean.FALSE;
         } else {
             return null;
@@ -63,6 +63,6 @@ public final class SOAP11Helper extends SOAPHelper {
 
     @Override
     public String formatBoolean(boolean value) {
-        return value ? "1" : "0";
+        return String.valueOf(value);
     }
 }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/factory/SOAP11Factory.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/factory/SOAP11Factory.java
@@ -27,8 +27,8 @@ import org.apache.axiom.soap.SOAPFaultReason;
 import org.apache.axiom.soap.SOAPFaultSubCode;
 import org.apache.axiom.soap.SOAPFaultText;
 import org.apache.axiom.soap.SOAPFaultValue;
+import org.apache.axiom.soap.impl.common.soap11.SOAP11Helper;
 import org.apache.axiom.soap.impl.intf.SOAPHelper;
-import org.apache.axiom.soap.impl.intf.soap11.SOAP11Helper;
 
 public class SOAP11Factory extends SOAPFactoryImpl {
     public SOAP11Factory(AxiomNodeFactory nodeFactory) {

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/factory/SOAP12Factory.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/factory/SOAP12Factory.java
@@ -29,8 +29,8 @@ import org.apache.axiom.soap.SOAPFaultReason;
 import org.apache.axiom.soap.SOAPFaultSubCode;
 import org.apache.axiom.soap.SOAPFaultText;
 import org.apache.axiom.soap.SOAPFaultValue;
+import org.apache.axiom.soap.impl.common.soap12.SOAP12Helper;
 import org.apache.axiom.soap.impl.intf.SOAPHelper;
-import org.apache.axiom.soap.impl.intf.soap12.SOAP12Helper;
 
 public class SOAP12Factory extends SOAPFactoryImpl {
     public SOAP12Factory(AxiomNodeFactory nodeFactory) {

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/intf/SOAPHelper.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/intf/SOAPHelper.java
@@ -21,9 +21,7 @@ package org.apache.axiom.soap.impl.intf;
 import javax.xml.namespace.QName;
 import org.apache.axiom.om.OMMetaFactory;
 import org.apache.axiom.om.OMNamespace;
-import org.apache.axiom.om.impl.common.OMNamespaceImpl;
 import org.apache.axiom.om.impl.intf.factory.AxiomElementType;
-import org.apache.axiom.soap.SOAPConstants;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.SOAPVersion;
 
@@ -32,167 +30,56 @@ import org.apache.axiom.soap.SOAPVersion;
  * added to {@link SOAPVersion}, but that are not relevant for application code and should therefore
  * not be part of the public API.
  */
-public abstract class SOAPHelper {
-    private final SOAPVersion version;
-    private final OMNamespace namespace;
-    private final String specName;
-    private final AxiomElementType<? extends AxiomSOAPEnvelope> envelopeType;
-    private final AxiomElementType<? extends AxiomSOAPHeader> headerType;
-    private final QName headerQName;
-    private final AxiomElementType<? extends AxiomSOAPHeaderBlock> headerBlockType;
-    private final AxiomElementType<? extends AxiomSOAPBody> bodyType;
-    private final QName bodyQName;
-    private final AxiomElementType<? extends AxiomSOAPFault> faultType;
-    private final QName faultQName;
-    private final AxiomElementType<? extends AxiomSOAPFaultCode> faultCodeType;
-    private final AxiomElementType<? extends AxiomSOAPFaultReason> faultReasonType;
-    private final AxiomElementType<? extends AxiomSOAPFaultRole> faultRoleType;
-    private final AxiomElementType<? extends AxiomSOAPFaultDetail> faultDetailType;
-    private final QName mustUnderstandAttributeQName;
-    private final QName roleAttributeQName;
-    private final QName relayAttributeQName;
+public interface SOAPHelper {
+    SOAPVersion getVersion();
 
-    protected SOAPHelper(
-            SOAPVersion version,
-            String specName,
-            AxiomElementType<? extends AxiomSOAPEnvelope> envelopeType,
-            AxiomElementType<? extends AxiomSOAPHeader> headerType,
-            AxiomElementType<? extends AxiomSOAPHeaderBlock> headerBlockType,
-            AxiomElementType<? extends AxiomSOAPBody> bodyType,
-            AxiomElementType<? extends AxiomSOAPFault> faultType,
-            AxiomElementType<? extends AxiomSOAPFaultCode> faultCodeType,
-            AxiomElementType<? extends AxiomSOAPFaultReason> faultReasonType,
-            AxiomElementType<? extends AxiomSOAPFaultRole> faultRoleType,
-            AxiomElementType<? extends AxiomSOAPFaultDetail> faultDetailType,
-            String roleAttributeLocalName,
-            String relayAttributeLocalName) {
-        this.version = version;
-        namespace = new OMNamespaceImpl(version.getEnvelopeURI(), SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        this.specName = specName;
-        this.envelopeType = envelopeType;
-        this.headerType = headerType;
-        headerQName = new QName(
-                version.getEnvelopeURI(), SOAPConstants.HEADER_LOCAL_NAME, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        this.headerBlockType = headerBlockType;
-        this.bodyType = bodyType;
-        bodyQName = new QName(
-                version.getEnvelopeURI(), SOAPConstants.BODY_LOCAL_NAME, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        this.faultType = faultType;
-        faultQName = new QName(
-                version.getEnvelopeURI(),
-                SOAPConstants.SOAPFAULT_LOCAL_NAME,
-                SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        this.faultCodeType = faultCodeType;
-        this.faultReasonType = faultReasonType;
-        this.faultRoleType = faultRoleType;
-        this.faultDetailType = faultDetailType;
-        mustUnderstandAttributeQName = new QName(
-                version.getEnvelopeURI(),
-                SOAPConstants.ATTR_MUSTUNDERSTAND,
-                SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        roleAttributeQName = new QName(
-                version.getEnvelopeURI(), roleAttributeLocalName, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-        relayAttributeQName = relayAttributeLocalName == null
-                ? null
-                : new QName(
-                        version.getEnvelopeURI(), relayAttributeLocalName, SOAPConstants.SOAP_DEFAULT_NAMESPACE_PREFIX);
-    }
+    SOAPFactory getSOAPFactory(OMMetaFactory metaFactory);
 
-    public final SOAPVersion getVersion() {
-        return version;
-    }
+    String getEnvelopeURI();
 
-    public abstract SOAPFactory getSOAPFactory(OMMetaFactory metaFactory);
+    OMNamespace getNamespace();
 
-    public final String getEnvelopeURI() {
-        return version.getEnvelopeURI();
-    }
+    String getSpecName();
 
-    public final OMNamespace getNamespace() {
-        return namespace;
-    }
+    AxiomElementType<? extends AxiomSOAPEnvelope> getEnvelopeType();
 
-    public final String getSpecName() {
-        return specName;
-    }
+    AxiomElementType<? extends AxiomSOAPHeader> getHeaderType();
 
-    public final AxiomElementType<? extends AxiomSOAPEnvelope> getEnvelopeType() {
-        return envelopeType;
-    }
+    QName getHeaderQName();
 
-    public final AxiomElementType<? extends AxiomSOAPHeader> getHeaderType() {
-        return headerType;
-    }
+    AxiomElementType<? extends AxiomSOAPHeaderBlock> getHeaderBlockType();
 
-    public final QName getHeaderQName() {
-        return headerQName;
-    }
+    AxiomElementType<? extends AxiomSOAPBody> getBodyType();
 
-    public final AxiomElementType<? extends AxiomSOAPHeaderBlock> getHeaderBlockType() {
-        return headerBlockType;
-    }
+    QName getBodyQName();
 
-    public final AxiomElementType<? extends AxiomSOAPBody> getBodyType() {
-        return bodyType;
-    }
+    AxiomElementType<? extends AxiomSOAPFault> getFaultType();
 
-    public final QName getBodyQName() {
-        return bodyQName;
-    }
+    QName getFaultQName();
 
-    public final AxiomElementType<? extends AxiomSOAPFault> getFaultType() {
-        return faultType;
-    }
+    AxiomElementType<? extends AxiomSOAPFaultCode> getFaultCodeType();
 
-    public final QName getFaultQName() {
-        return faultQName;
-    }
+    QName getFaultCodeQName();
 
-    public final AxiomElementType<? extends AxiomSOAPFaultCode> getFaultCodeType() {
-        return faultCodeType;
-    }
+    AxiomElementType<? extends AxiomSOAPFaultReason> getFaultReasonType();
 
-    public final QName getFaultCodeQName() {
-        return version.getFaultCodeQName();
-    }
+    QName getFaultReasonQName();
 
-    public final AxiomElementType<? extends AxiomSOAPFaultReason> getFaultReasonType() {
-        return faultReasonType;
-    }
+    AxiomElementType<? extends AxiomSOAPFaultRole> getFaultRoleType();
 
-    public final QName getFaultReasonQName() {
-        return version.getFaultReasonQName();
-    }
+    QName getFaultRoleQName();
 
-    public final AxiomElementType<? extends AxiomSOAPFaultRole> getFaultRoleType() {
-        return faultRoleType;
-    }
+    AxiomElementType<? extends AxiomSOAPFaultDetail> getFaultDetailType();
 
-    public final QName getFaultRoleQName() {
-        return version.getFaultRoleQName();
-    }
+    QName getFaultDetailQName();
 
-    public final AxiomElementType<? extends AxiomSOAPFaultDetail> getFaultDetailType() {
-        return faultDetailType;
-    }
+    QName getMustUnderstandAttributeQName();
 
-    public final QName getFaultDetailQName() {
-        return version.getFaultDetailQName();
-    }
+    QName getRoleAttributeQName();
 
-    public final QName getMustUnderstandAttributeQName() {
-        return mustUnderstandAttributeQName;
-    }
+    QName getRelayAttributeQName();
 
-    public final QName getRoleAttributeQName() {
-        return roleAttributeQName;
-    }
+    Boolean parseBoolean(String literal);
 
-    public final QName getRelayAttributeQName() {
-        return relayAttributeQName;
-    }
-
-    public abstract Boolean parseBoolean(String literal);
-
-    public abstract String formatBoolean(boolean value);
+    String formatBoolean(boolean value);
 }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP11ElementMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP11ElementMixin.java
@@ -18,9 +18,9 @@
  */
 package org.apache.axiom.soap.impl.mixin;
 
+import org.apache.axiom.soap.impl.common.soap11.SOAP11Helper;
 import org.apache.axiom.soap.impl.intf.SOAPHelper;
 import org.apache.axiom.soap.impl.intf.soap11.AxiomSOAP11Element;
-import org.apache.axiom.soap.impl.intf.soap11.SOAP11Helper;
 import org.apache.axiom.weaver.annotation.Mixin;
 
 @Mixin

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP12ElementMixin.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/soap/impl/mixin/AxiomSOAP12ElementMixin.java
@@ -18,9 +18,9 @@
  */
 package org.apache.axiom.soap.impl.mixin;
 
+import org.apache.axiom.soap.impl.common.soap12.SOAP12Helper;
 import org.apache.axiom.soap.impl.intf.SOAPHelper;
 import org.apache.axiom.soap.impl.intf.soap12.AxiomSOAP12Element;
-import org.apache.axiom.soap.impl.intf.soap12.SOAP12Helper;
 import org.apache.axiom.weaver.annotation.Mixin;
 
 @Mixin


### PR DESCRIPTION
This should make it easier to enforce proper layering and avoid cycles.

Also move the implementation classes to avoid a cycle.