### PR TITLE
Make the factoryIsSingleton test meaningful again

### DIFF
--- a/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/factory/OMFactoryTests.java
+++ b/testing/axiom-testsuite/src/main/java/org/apache/axiom/ts/om/factory/OMFactoryTests.java
@@ -243,7 +243,7 @@ public class OMFactoryTests {
      */
     @Test
     public void factoryIsSingleton() throws Throwable {
-        assertThat(factory).isSameAs(factory);
+        assertThat(metaFactory.getOMFactory()).isSameAs(metaFactory.getOMFactory());
     }
 
     /**


### PR DESCRIPTION
Some AI assisted refactoring resulted in the assertion in that test becoming trivial. Fix the test to restore the original intention.