### PR TITLE
Annotate TextContent.blobObject with @Union(Blob, BlobProvider)

### DIFF
--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/intf/TextContent.java
@@ -46,7 +46,7 @@ public final class TextContent implements CloneableCharacterData {
      * Contains a {@link Blob} or {@link BlobProvider} object if the text node represents base64
      * encoded binary data.
      */
-    private Object blobObject;
+    private @Union(types = {Blob.class, BlobProvider.class}) Object blobObject;
 
     private boolean optimize;
     private boolean binary;
@@ -55,7 +55,8 @@ public final class TextContent implements CloneableCharacterData {
         this.value = value;
     }
 
-    public TextContent(String contentID, Object blobObject, boolean optimize) {
+    public TextContent(
+            String contentID, @Union(types = {Blob.class, BlobProvider.class}) Object blobObject, boolean optimize) {
         this.value = null;
         this.contentID = contentID;
         this.blobObject = blobObject;
@@ -107,7 +108,7 @@ public final class TextContent implements CloneableCharacterData {
      *
      * @return a {@link Blob} or {@link BlobProvider} object for the base64 decoded content
      */
-    public Object getBlobObject() {
+    public @Union(types = {Blob.class, BlobProvider.class}) Object getBlobObject() {
         if (!binary) {
             throw new IllegalStateException();
         }

--- a/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/xop/XOPEncodingFilterHandler.java
+++ b/mixins/om-mixins/src/main/java/org/apache/axiom/om/impl/stream/xop/XOPEncodingFilterHandler.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.axiom.blob.Blob;
+import org.apache.axiom.checker.union.Union;
 import org.apache.axiom.core.stream.StreamException;
 import org.apache.axiom.core.stream.XmlHandler;
 import org.apache.axiom.core.stream.xop.AbstractXOPEncodingFilterHandler;
@@ -34,7 +35,8 @@ import org.apache.axiom.om.impl.intf.TextContent;
 
 public final class XOPEncodingFilterHandler extends AbstractXOPEncodingFilterHandler
         implements XOPHandler, OMAttachmentAccessor {
-    private final Map<String, Object> blobObjects = new LinkedHashMap<String, Object>();
+    private final Map<String, @Union(types = {Blob.class, BlobProvider.class}) Object> blobObjects =
+            new LinkedHashMap<String, @Union(types = {Blob.class, BlobProvider.class}) Object>();
     private final ContentIDGenerator contentIDGenerator;
     private final OptimizationPolicy optimizationPolicy;
 


### PR DESCRIPTION
The field, getter and constructor parameter holding either a Blob or a BlobProvider now use @Union so the checker framework verifies the instanceof-based narrowing. The Map of pending blobs in XOPEncodingFilterHandler is annotated the same way since it stores the same union of types.