### PR TITLE
Wire the security threat model for agent discoverability (AGENTS.md + SECURITY.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,10 @@ Replace `<module>` with the Maven module path(s) you modified (e.g. `axiom-api`,
 ```
 
 **CI will fail if spotless has not been applied.**
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/ws-axiom` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in [THREAT-MODEL.md](./THREAT-MODEL.md).


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or
discuss as needed.** Nothing here is a requirement; the maintainer is the
decision-maker.

This wires up the security model that already landed in this repo
(`THREAT-MODEL.md`) so an automated scan agent can discover it
mechanically, via the conventional `AGENTS.md` → `SECURITY.md` → model
chain. It adds no model content and changes none of the existing text.

Context: the ASF Security team is preparing this project for an automated
agentic security scan we're piloting. Such scans refuse to run when the
model isn't reachable by that path — refusing upfront beats spending PMC
reviewer cycles on a noise-heavy run against a model the agent never
found. Discoverability is the one hard gate; everything else is
suggestion.

This is a follow-up to the threat-model PR already merged here: that one
added the document, but not the small pointer files the scan agent needs
to *find* it. That omission was ours, not the PMC's.

Questions or pushback welcome — happy to adjust wording or file placement
to match the project's house style.
